### PR TITLE
Fix `SimulateHwMechanism`

### DIFF
--- a/src/Src/BouncyHsm.Core/Services/P11Handlers/GetMechanismInfoHandler.cs
+++ b/src/Src/BouncyHsm.Core/Services/P11Handlers/GetMechanismInfoHandler.cs
@@ -36,7 +36,7 @@ public partial class GetMechanismInfoHandler : IRpcRequestHandler<GetMechanismIn
                     MechanismType = request.MechanismType,
                     MinKeySize = mechanismInfo.MinKeySize,
                     MaxKeySize = mechanismInfo.MaxKeySize,
-                    Flags = (uint)((slot.Token.SimulateHwMechanism) ? mechanismInfo.Flags : mechanismInfo.Flags | MechanismCkf.CKF_HW)
+                    Flags = (uint)(slot.Token.SimulateHwMechanism ? (mechanismInfo.Flags | MechanismCkf.CKF_HW) : mechanismInfo.Flags)
                 }
             };
         }


### PR DESCRIPTION
The original implementation incorrectly inverted the `SimulateHwMechanism` flag. As a result, when `SimulateHwMechanism` is set to true, it does not simulate a hardware mechanism, and when set to false, it does simulate one, which is incorrect.

This PR restores the correct behavior by inverting the if condition, ensuring that the flag functions as intended.