### PR TITLE
add dedicated macos build instructions

### DIFF
--- a/build_macos/Makefile
+++ b/build_macos/Makefile
@@ -1,0 +1,49 @@
+SRC_DIR     := ../src/Src/BouncyHsm.Pkcs11Lib
+BUILD_DIR   := build
+CC          := clang
+CFLAGS_BASE := -Wall -Wextra -O2 -fPIC \
+               -I$(SRC_DIR) \
+               -include $(CURDIR)/shim.h
+
+ARCH_FLAGS_x64   := -arch x86_64
+ARCH_FLAGS_arm64 := -arch arm64
+
+SRCS      := $(wildcard $(SRC_DIR)/*.c) \
+             $(wildcard $(SRC_DIR)/rpc/*.c) \
+             $(wildcard $(SRC_DIR)/utils/*.c)
+REL_SRCS  := $(patsubst $(SRC_DIR)/%,%,$(SRCS))
+OBJS_x64  := $(patsubst %.c,$(BUILD_DIR)/x64/%.o,$(REL_SRCS))
+OBJS_arm64:= $(patsubst %.c,$(BUILD_DIR)/arm64/%.o,$(REL_SRCS))
+
+HDRS := $(wildcard $(SRC_DIR)/*.h) \
+        $(wildcard $(SRC_DIR)/rpc/*.h) \
+        $(wildcard $(SRC_DIR)/utils/*.h)
+
+.PHONY: all clean universal
+all: BouncyHsm.Pkcs11Lib-x64.dylib BouncyHsm.Pkcs11Lib-arm64.dylib
+
+BouncyHsm.Pkcs11Lib-x64.dylib: $(OBJS_x64)
+	$(CC) $(CFLAGS_BASE) $(ARCH_FLAGS_x64) -dynamiclib \
+	    -install_name @rpath/$@ -o $@ $^
+
+BouncyHsm.Pkcs11Lib-arm64.dylib: $(OBJS_arm64)
+	$(CC) $(CFLAGS_BASE) $(ARCH_FLAGS_arm64) -dynamiclib \
+	    -install_name @rpath/$@ -o $@ $^
+
+$(BUILD_DIR)/x64/%.o: $(SRC_DIR)/%.c $(HDRS)
+	mkdir -p $(@D)
+	$(CC) $(CFLAGS_BASE) $(ARCH_FLAGS_x64) -c $< -o $@
+
+$(BUILD_DIR)/arm64/%.o: $(SRC_DIR)/%.c $(HDRS)
+	mkdir -p $(@D)
+	$(CC) $(CFLAGS_BASE) $(ARCH_FLAGS_arm64) -c $< -o $@
+
+universal: all
+	lipo -create \
+	    -output BouncyHsm.Pkcs11Lib.dylib \
+	    BouncyHsm.Pkcs11Lib-x64.dylib \
+	    BouncyHsm.Pkcs11Lib-arm64.dylib
+
+clean:
+	rm -rf $(BUILD_DIR)
+	rm -f BouncyHsm.Pkcs11Lib*.dylib

--- a/build_macos/README.md
+++ b/build_macos/README.md
@@ -1,0 +1,6 @@
+# Build PKCS#11 Lib for macOS (x86 & ARM)
+
+- Navigate to [build_macos](.) folder in your terminal
+- Execute `make` or `make universal` to build the **.dylib** files for each arch type
+
+Use `make clean` to delete build files.

--- a/build_macos/shim.h
+++ b/build_macos/shim.h
@@ -1,0 +1,60 @@
+#ifndef MACOS_SHIM_H
+#define MACOS_SHIM_H
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>   // gethostname
+#include <stdbool.h>
+
+// Define newline macro for cross-platform compatibility
+#define NEW_LINE_STR "\n"
+
+// Emulate Microsoft-secure functions using standard C/POSIX APIs
+#ifndef strcpy_s
+#define strcpy_s(dest, destsz, src)                                     \
+    (((size_t)strlen(src) + 1 > (destsz))                               \
+         ? (errno = EINVAL)                                             \
+         : memcpy((dest), (src), strlen(src) + 1))
+#endif
+
+#ifndef strncpy_s
+#define strncpy_s(dest, destsz, src, count)                             \
+    do {                                                                \
+        size_t _len = strnlen((src), (count));                          \
+        if (_len + 1 > (destsz)) {                                      \
+            errno = EINVAL;                                             \
+        } else {                                                        \
+            memcpy((dest), (src), _len);                                \
+            (dest)[_len] = '\0';                                        \
+        }                                                               \
+    } while (0)
+#endif
+
+#ifndef memcpy_s
+#define memcpy_s(dest, destsz, src, count)                              \
+    (((count) > (destsz))                                               \
+         ? (errno = EINVAL)                                             \
+         : memcpy((dest), (src), (count)))
+#endif
+
+/**
+ * Provide GetCurrentCompiuterName for macOS
+ * (matches platformHelper.h signature)
+ */
+static inline bool GetCurrentCompiuterName(char *buffer, size_t maxSize)
+{
+    if (buffer == NULL || maxSize == 0) {
+        return false;
+    }
+
+    if (gethostname(buffer, maxSize) != 0) {
+        return false;
+    }
+
+    buffer[maxSize - 1] = '\0';
+    return true;
+}
+
+#endif


### PR DESCRIPTION
Hello,

first of all, I love your project as it is far better than [SoftHSM v2](https://github.com/softhsm/SoftHSMv2) and more easy to use ❤️ .

Unfortunately, I had major problems getting the existing PKCS#11 libraries to run on macOS. The existing instructions under [this link](https://github.com/harrison314/BouncyHsm/blob/main/Doc/BuildPkcs11Lib.md#makefile-parameters) & [this link](https://github.com/harrison314/BouncyHsm/issues/28) did not help either. Therefore I added new instructions to build the PKCS#11 library for all macOS architectures. I also had to provide some functions (shim.h) as they are not available on MacOS. 

The fix for GetCurrentCompiuterName might be applied directly to the origin location under platformHelper.h.

Keep up with the good work ✌️ 

