### PR TITLE
fix: resolve LastActivity race condition under concurrent PKCS#11 calls

### DIFF
--- a/src/Src/BouncyHsm.Infrastructure/Cap/InMemory/MemorySession.cs
+++ b/src/Src/BouncyHsm.Infrastructure/Cap/InMemory/MemorySession.cs
@@ -34,9 +34,17 @@ public class MemorySession : IMemorySession
     public DateTimeOffset LastActivity
     {
         get => this.lastActivity;
-        set => this.lastActivity = (value >= this.lastActivity)
-            ? value
-            : throw new ArgumentException("The last activity must be later than the start and the last activity.", nameof(this.LastActivity));
+        set
+        {
+            // Under concurrent HTTP requests from the Kestrel thread pool,
+            // a thread that called GetUtcNow() earlier may execute the setter
+            // after a thread that got a later timestamp, making value < lastActivity.
+            // Silently keep the maximum — this is benign for session-expiry bookkeeping.
+            if (value > this.lastActivity)
+            {
+                this.lastActivity = value;
+            }
+        }
     }
 
     public MemorySession(MemorySessionData sessionData, DateTimeOffset startAt)


### PR DESCRIPTION
MemorySession.LastActivity setter throws ArgumentException when two Kestrel thread pool threads execute the setter out of timestamp order: Thread A gets T=100, Thread B gets T=101, B writes first, then A sees lastActivity=101 and fails the >= check with its stale T=100 value.

Replace the throwing setter with a silent monotonic update that keeps the maximum timestamp. LastActivity is only used for session-expiry housekeeping so being off by one tick is harmless.

Fixes: #88