### PR TITLE
Fix InMemory storage: slot not plugged

### DIFF
--- a/src/Src/BouncyHsm.Infrastructure/Storage/InMemory/MemoryPersistentRepository.cs
+++ b/src/Src/BouncyHsm.Infrastructure/Storage/InMemory/MemoryPersistentRepository.cs
@@ -32,6 +32,7 @@ internal class MemoryPersistentRepository : IPersistentRepository
                 SlotId = 1457,
                 Description = "Example",
                 IsHwDevice = false,
+                IsPlugged = true,
                 Token = new InMemoryTokenInfo()
                 {
                     Label = "Example token",
@@ -61,9 +62,10 @@ internal class MemoryPersistentRepository : IPersistentRepository
         SlotEntity slotEntity = new SlotEntity()
         {
             Id = Guid.NewGuid(),
-            SlotId = this.slots.Select(t => t.SlotId).Max() + 1,
+            SlotId = this.slots.Max(t => t.SlotId) + 1,
             Description = slot.Description,
             IsHwDevice = slot.IsHwDevice,
+            IsRemovableDevice = slot.IsRemovableDevice,
             Token = new InMemoryTokenInfo()
             {
                 Label = slot.Token.Label,


### PR DESCRIPTION
Doing some testing with `PersistenceStorageType=InMemory` and it seems like `C_GetSlotList(true)` returns empty due to the token not being plugged in?